### PR TITLE
Fix tinymce issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'pg', '~> 0.15'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+# gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.1.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,9 +250,6 @@ GEM
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.7.2)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
     warden (1.2.6)
       rack (>= 1.0)
     web-console (2.3.0)
@@ -296,7 +293,6 @@ DEPENDENCIES
   spring
   tinymce-rails
   turbolinks
-  uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
 BUNDLED WITH

--- a/app/assets/javascripts/everything.js
+++ b/app/assets/javascripts/everything.js
@@ -1,10 +1,15 @@
 $(document).on('page:change', function(event){
+  bindResumeShowListeners();
+})
+
+
+
+$(document).ready(function(event){
   console.log("hello!");
   bindAssetListeners();
   bindDetailEvents();
   bindEditListeners();
   bindFineTuneListeners();
-  bindResumeShowListeners();
   bindResumeIndexListeners();
   openingAnimation();
   bindWebsiteListeners();
@@ -486,9 +491,8 @@ var newWebsite = function(e) {
 var submitWebsite = function(e) {
   e.preventDefault();
   var userId = $('#new-website-button')[0].attributes.user_id.value;
-
-  var data = $("#new-website-form").serialize();
-  debugger;
+  var data = $("#new_website").serialize();
+  console.log(data);
   $.ajax({
     url: "/users/" + userId + "/websites",
     method: "POST",

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
@drothschild @rochej @garywong89 

Hey everyone

I **_think_** I fixed the tiny mce vs heroku issue.  This pull request has my changes in it, but I want to discuss it before we really implement it...
1.  I took out the uglifier gem
2.  I took out the line in the production config that calls uglifier
3.  I was able to deploy to heroku on my own copy of the app.  I was unable to push to heroku on our app because of what I suspect were our force push attempts.  It kept saying I can't push because the remote has work that I don't have.  I assume that's left over from Roche's tries from the other computer.

Caveat... I don't know what uglifier really does for us.  So if this is something we really truly want or need, this isn't the route to go.  If we can live without it, this might do it.
